### PR TITLE
changes wording for $0 as savings instead of overspend

### DIFF
--- a/client/components/dashboard/SavingsProgressBars.jsx
+++ b/client/components/dashboard/SavingsProgressBars.jsx
@@ -57,7 +57,7 @@ class SavingsProgressBars extends React.Component {
             <br/>
             {this.renderProgressBar()}
             <br/>
-            { item.total_savings_in_cents > 0 
+            { item.total_savings_in_cents >= 0 
               ?
               <p>Total Savings: ${(item.total_savings_in_cents/100).toFixed(2)}</p>
               :

--- a/client/components/dashboard/TotalSavings.jsx
+++ b/client/components/dashboard/TotalSavings.jsx
@@ -39,7 +39,7 @@ function TotalSavings (props) {
      {/* Ternary to deal with 'negative' savings */}
       <h1 className="has-text-weight-bold">Hello {capitalizeFirstLetter(userName)}!</h1>  
         {props.totals[0] && 
-          (props.totals[0].totalsavings > 0 
+          (props.totals[0].totalsavings >= 0 
         ?
           <h1>Your total Savings : $ {(props.totals[0].totalsavings/100).toFixed(2)}</h1>
         :


### PR DESCRIPTION
fixes #27 - when 0 savings now says your total savings: $0 instead of your total overspend: $0