### PR TITLE
fixes error of wrong data being pulled into editItem fn

### DIFF
--- a/client/components/AddedItems.jsx
+++ b/client/components/AddedItems.jsx
@@ -32,49 +32,41 @@ class AddedItems extends React.Component {
 
 	editItem(e, item) {
 		e.preventDefault()
-		//**Converts edited dollars to cents**
-		// Using or operator (||) to only update field if the field has been changed
-		// let updateItem is setting the values of the item object that is being edited. If value has been edited, it will take this.state. If value is unchanged, it will take this.props.
-		console.log("Props ", this.props.shoppingList)
-		console.log("what's your id? ", item.id, this.state.name, this.state.cost, this.state.quantity)
+		// let updateItem is setting the values of the item object that is being edited. Using or operator (||) to only update field if the field has been changed
 
 		let updateItem = {
 				id: item.id,
 
-				name: this.state.name || this.props.shoppingList[item.id].name,
+				name: this.state.name || item.name,
 
-				quantity: this.state.quantity || this.props.shoppingList[item.id].quantity,
+				quantity: this.state.quantity || item.quantity,
 
-				unit_cost_in_cents: this.state.cost*100 || this.props.shoppingList[item.id].unit_cost_in_cents,
+				unit_cost_in_cents: this.state.cost*100 || item.unit_cost_in_cents,
 				
-				total_cost_in_cents: this.state.cost*100 * this.state.quantity || this.props.shoppingList[item.id].unit_cost_in_cents * this.props.shoppingList[item.id].quantity 
+				total_cost_in_cents: this.state.cost*100 * this.state.quantity || item.unit_cost_in_cents * item.quantity 
 			}
-			// console.log("update item object before we play with it", updateItem)
 			
-			let updatedName = updateItem.name
-			let updatedQuantity = updateItem.quantity
-			let updatedUnit_cost_in_cents = updateItem.unit_cost_in_cents
-			let updatedTotal_cost_in_cents = updateItem.unit_cost_in_cents *updateItem.quantity
+    let updatedName = updateItem.name
+    let updatedQuantity = updateItem.quantity
+    let updatedUnit_cost_in_cents = updateItem.unit_cost_in_cents
+    let updatedTotal_cost_in_cents = updateItem.unit_cost_in_cents *updateItem.quantity
 			
-			updateItem = { 
-				id: item.id, 
-				name: updatedName, 
-				quantity: updatedQuantity, 
-				unit_cost_in_cents: updatedUnit_cost_in_cents, total_cost_in_cents: updatedTotal_cost_in_cents
-			}
-			console.log("New updateItem object: ", updateItem) 
+    updateItem = { 
+      id: item.id, 
+      name: updatedName, 
+      quantity: updatedQuantity, 
+      unit_cost_in_cents: updatedUnit_cost_in_cents, total_cost_in_cents: updatedTotal_cost_in_cents
+    }
 
 		// **Below code calculates the value to be dispatched to addToTotalSpend when item edited (the difference between original value and new value)**
-		// originalCost to take existing value in shoppingList object and compares this to the new value entered into input box, via the checkNewCost function.
 		// checkNewCost function compares original and new cost. If the do not match, then take the value from updateItem object (above). Otherwise, take the value from the originalCost variable. This result is then used in the calculation that makes up the diffCost value which is dispatched into addToTotalSpend.
-		// Solves previous bug where if value wasn't updated during the edit (e.g. only item name updated), then value coming in was producing NaN value in totalSpend.
 			
-		let originalCost = this.props.shoppingList[item.id].total_cost_in_cents // CHECK - unit or total cost in cents?
-		let newCost = this.state.total_cost_in_cents*100 * this.state.quantity
+    let originalCost = item.total_cost_in_cents
+    let newCost = updateItem.total_cost_in_cents
 
 		function checkNewCost () {
 			if (originalCost !== newCost) {
-				return updateItem.total_cost_in_cents 
+				return newCost
 			} else {
 				return originalCost
 			}
@@ -90,8 +82,8 @@ class AddedItems extends React.Component {
 			messageCost : checkValid.messageCost,
 			valid : checkValid.valid
 		})
-		// console.log('checking if valid: ',checkValid, checkValid.valid)
-		if(checkValid.valid) {
+
+    if(checkValid.valid) {
 			this.props.dispatch(editShoppingListItem(updateItem)) // Send updated item object to editShoppingListItem //
 			this.props.dispatch(addToTotalSpend(diffCost)) // Send the value of the difference in cost to addToTotalSpend //
 			this.toggleForm() // Toggle the view from input fields back to text, showing the now updated values of item and cost //
@@ -178,7 +170,6 @@ class AddedItems extends React.Component {
 }
   
 const mapStateToProps = (state) => {
-    console.log(state)
     return {
         shoppingList: state.shoppingList
         }


### PR DESCRIPTION
edit item function used wrong data when comparing with potential change in state.
e.g. was name: this.state.name || this.props.shoppingList[item.id].name,
now is this.state.name || item.name,

also fixes how data is compared for checkNewCost
was:
let originalCost = this.props.shoppingList[item.id].total_cost_in_cents 
let newCost = this.state.total_cost_in_cents*100 * this.state.quantity

now: 
let originalCost = item.total_cost_in_cents
let newCost = updateItem.total_cost_in_cents
